### PR TITLE
Bump version

### DIFF
--- a/src/samerlib.app.src
+++ b/src/samerlib.app.src
@@ -2,7 +2,7 @@
 
 {application, samerlib,
  [{description, "A bucket for low level, very common functionality"},
-  {vsn, "0.8.0c"},
+  {vsn, "0.8.0e"},
   {modules, []},
   {registered, []},
   {applications, [kernel, stdlib]},


### PR DESCRIPTION
It seems like when version `0.8.0e` was tagged, an update to `src/samerlib.app.src` got missed. Attached commit fixes that. Alternatively, version string could be replaced by `git`.

HTH